### PR TITLE
Port to ClientWebSocket

### DIFF
--- a/.github/workflows/csc.yml
+++ b/.github/workflows/csc.yml
@@ -23,29 +23,7 @@ jobs:
           
       - name: Install MSBuild to PATH
         uses: microsoft/setup-msbuild@v1.1
-        
-      - name: Download WebSocket-Sharp 1.0.3rc11
-        # Fine, I'll play dirty.
-        uses: carlosperate/download-file-action@v1.0.3
-        with:
-          file-url: 'https://www.nuget.org/api/v2/package/WebSocketSharp/1.0.3-rc11'
-          file-name: websocketsharp.nupkg
-          location: './tmp'
-      
-      - name: Extract WebSocket-Sharp with 7z
-        run: |
-          cd tmp
-          7z x websocketsharp.nupkg
-          copy .\lib\websocket-sharp.dll D:\a\collab-vm-csharp-client\collab-vm-csharp-client\
-        
-      - name: Copy WebSocket-Sharp to build folders
-        run: |
-          cd D:\a\collab-vm-csharp-client\collab-vm-csharp-client\
-          mkdir ./bin/Debug
-          mkdir ./bin/Release
-          copy websocket-sharp.dll bin\Release
-          copy websocket-sharp.dll bin\Debug
-      
+
       - name: Use MSBuild to compile debug version
         run: msbuild 
         

--- a/ConnectDialog.Designer.cs
+++ b/ConnectDialog.Designer.cs
@@ -32,207 +32,191 @@ namespace CollabClient
         /// </summary>
         private void InitializeComponent()
         {
-			System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(ConnectDialog));
-			this.textBox = new System.Windows.Forms.TextBox();
-			this.textBox2 = new System.Windows.Forms.TextBox();
-			this.textBox3 = new System.Windows.Forms.TextBox();
-			this.okButton = new System.Windows.Forms.Button();
-			this.cancelButton = new System.Windows.Forms.Button();
-			this.namewarning = new System.Windows.Forms.Label();
-			this.iptext = new System.Windows.Forms.Label();
-			this.nametext = new System.Windows.Forms.Label();
-			this.presetlabel = new System.Windows.Forms.Label();
-			this.cb = new System.Windows.Forms.ComboBox();
-			this.checksecure = new System.Windows.Forms.CheckBox();
-			this.checkcompression = new System.Windows.Forms.CheckBox();
-			this.SuspendLayout();
-			// 
-			// textBox
-			// 
-			this.textBox.BackColor = System.Drawing.Color.DimGray;
-			this.textBox.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
-			this.textBox.ForeColor = System.Drawing.Color.White;
-			this.textBox.Location = new System.Drawing.Point(25, 5);
-			this.textBox.Name = "textBox";
-			this.textBox.Size = new System.Drawing.Size(145, 20);
-			this.textBox.TabIndex = 0;
-			this.textBox.Text = Globals.vmip;
-			// 
-			// textBox2
-			// 
-			this.textBox2.BackColor = System.Drawing.Color.DimGray;
-			this.textBox2.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
-			this.textBox2.ForeColor = System.Drawing.Color.White;
-			this.textBox2.Location = new System.Drawing.Point(169, 5);
-			this.textBox2.Name = "textBox2";
-			this.textBox2.Size = new System.Drawing.Size(45, 20);
-			this.textBox2.TabIndex = 1;
-			this.textBox2.Text = Globals.vmname;
-			// 
-			// textBox3
-			// 
-			this.textBox3.BackColor = System.Drawing.Color.DimGray;
-			this.textBox3.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
-			this.textBox3.ForeColor = System.Drawing.Color.White;
-			this.textBox3.Location = new System.Drawing.Point(73, 24);
-			this.textBox3.Name = "textBox3";
-			this.textBox3.Size = new System.Drawing.Size(141, 20);
-			this.textBox3.TabIndex = 2;
-			this.textBox3.Text = Globals.vmusername;
-			this.textBox3.TextAlign = System.Windows.Forms.HorizontalAlignment.Center;
-			// 
-			// okButton
-			// 
-			this.okButton.BackColor = System.Drawing.Color.Gray;
-			this.okButton.DialogResult = System.Windows.Forms.DialogResult.OK;
-			this.okButton.FlatStyle = System.Windows.Forms.FlatStyle.Popup;
-			this.okButton.ForeColor = System.Drawing.SystemColors.ControlText;
-			this.okButton.Location = new System.Drawing.Point(60, 182);
-			this.okButton.Name = "okButton";
-			this.okButton.Size = new System.Drawing.Size(75, 23);
-			this.okButton.TabIndex = 5;
-			this.okButton.Text = "&Connect";
-			this.okButton.UseVisualStyleBackColor = false;
-			this.okButton.Click += new System.EventHandler(this.OkButton_Click);
-			// 
-			// cancelButton
-			// 
-			this.cancelButton.BackColor = System.Drawing.Color.Gray;
-			this.cancelButton.DialogResult = System.Windows.Forms.DialogResult.Cancel;
-			this.cancelButton.FlatStyle = System.Windows.Forms.FlatStyle.Popup;
-			this.cancelButton.ForeColor = System.Drawing.SystemColors.ControlText;
-			this.cancelButton.Location = new System.Drawing.Point(140, 182);
-			this.cancelButton.Name = "cancelButton";
-			this.cancelButton.Size = new System.Drawing.Size(75, 23);
-			this.cancelButton.TabIndex = 6;
-			this.cancelButton.Text = "&Quit";
-			this.cancelButton.UseVisualStyleBackColor = false;
-			this.cancelButton.Click += new System.EventHandler(this.CancelButton_Click);
-			// 
-			// namewarning
-			// 
-			this.namewarning.AutoSize = true;
-			this.namewarning.BackColor = System.Drawing.Color.Transparent;
-			this.namewarning.Font = new System.Drawing.Font("Microsoft Sans Serif", 9F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(238)));
-			this.namewarning.ForeColor = System.Drawing.Color.White;
-			this.namewarning.Location = new System.Drawing.Point(0, 68);
-			this.namewarning.Name = "namewarning";
-			this.namewarning.Size = new System.Drawing.Size(220, 60);
-			this.namewarning.TabIndex = 11;
-			this.namewarning.Text = "Usernames can only contain:\r\nANSI alphanumericals, spaces, dashes\r\nunderscores, a" +
+            System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(ConnectDialog));
+            this.textBox = new System.Windows.Forms.TextBox();
+            this.textBox2 = new System.Windows.Forms.TextBox();
+            this.textBox3 = new System.Windows.Forms.TextBox();
+            this.okButton = new System.Windows.Forms.Button();
+            this.cancelButton = new System.Windows.Forms.Button();
+            this.namewarning = new System.Windows.Forms.Label();
+            this.iptext = new System.Windows.Forms.Label();
+            this.nametext = new System.Windows.Forms.Label();
+            this.presetlabel = new System.Windows.Forms.Label();
+            this.cb = new System.Windows.Forms.ComboBox();
+            this.checksecure = new System.Windows.Forms.CheckBox();
+            this.SuspendLayout();
+            // 
+            // textBox
+            // 
+            this.textBox.BackColor = System.Drawing.Color.DimGray;
+            this.textBox.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
+            this.textBox.ForeColor = System.Drawing.Color.White;
+            this.textBox.Location = new System.Drawing.Point(25, 5);
+            this.textBox.Name = "textBox";
+            this.textBox.Size = new System.Drawing.Size(145, 20);
+            this.textBox.TabIndex = 0;
+            this.textBox.Text = "IP here, node name ->";
+            // 
+            // textBox2
+            // 
+            this.textBox2.BackColor = System.Drawing.Color.DimGray;
+            this.textBox2.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
+            this.textBox2.ForeColor = System.Drawing.Color.White;
+            this.textBox2.Location = new System.Drawing.Point(169, 5);
+            this.textBox2.Name = "textBox2";
+            this.textBox2.Size = new System.Drawing.Size(45, 20);
+            this.textBox2.TabIndex = 1;
+            this.textBox2.Text = "here";
+            // 
+            // textBox3
+            // 
+            this.textBox3.BackColor = System.Drawing.Color.DimGray;
+            this.textBox3.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
+            this.textBox3.ForeColor = System.Drawing.Color.White;
+            this.textBox3.Location = new System.Drawing.Point(73, 24);
+            this.textBox3.Name = "textBox3";
+            this.textBox3.Size = new System.Drawing.Size(141, 20);
+            this.textBox3.TabIndex = 2;
+            this.textBox3.Text = "collabvm-csharp-user";
+            this.textBox3.TextAlign = System.Windows.Forms.HorizontalAlignment.Center;
+            // 
+            // okButton
+            // 
+            this.okButton.BackColor = System.Drawing.Color.Gray;
+            this.okButton.DialogResult = System.Windows.Forms.DialogResult.OK;
+            this.okButton.FlatStyle = System.Windows.Forms.FlatStyle.Popup;
+            this.okButton.ForeColor = System.Drawing.SystemColors.ControlText;
+            this.okButton.Location = new System.Drawing.Point(60, 156);
+            this.okButton.Name = "okButton";
+            this.okButton.Size = new System.Drawing.Size(75, 23);
+            this.okButton.TabIndex = 5;
+            this.okButton.Text = "&Connect";
+            this.okButton.UseVisualStyleBackColor = false;
+            this.okButton.Click += new System.EventHandler(this.OkButton_Click);
+            // 
+            // cancelButton
+            // 
+            this.cancelButton.BackColor = System.Drawing.Color.Gray;
+            this.cancelButton.DialogResult = System.Windows.Forms.DialogResult.Cancel;
+            this.cancelButton.FlatStyle = System.Windows.Forms.FlatStyle.Popup;
+            this.cancelButton.ForeColor = System.Drawing.SystemColors.ControlText;
+            this.cancelButton.Location = new System.Drawing.Point(140, 156);
+            this.cancelButton.Name = "cancelButton";
+            this.cancelButton.Size = new System.Drawing.Size(75, 23);
+            this.cancelButton.TabIndex = 6;
+            this.cancelButton.Text = "&Quit";
+            this.cancelButton.UseVisualStyleBackColor = false;
+            this.cancelButton.Click += new System.EventHandler(this.CancelButton_Click);
+            // 
+            // namewarning
+            // 
+            this.namewarning.AutoSize = true;
+            this.namewarning.BackColor = System.Drawing.Color.Transparent;
+            this.namewarning.Font = new System.Drawing.Font("Microsoft Sans Serif", 9F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(238)));
+            this.namewarning.ForeColor = System.Drawing.Color.White;
+            this.namewarning.Location = new System.Drawing.Point(0, 68);
+            this.namewarning.Name = "namewarning";
+            this.namewarning.Size = new System.Drawing.Size(220, 60);
+            this.namewarning.TabIndex = 11;
+            this.namewarning.Text = "Usernames can only contain:\r\nANSI alphanumericals, spaces, dashes\r\nunderscores, a" +
     "nd periods, And it also\r\nmust be between 3 to 20 characters.";
-			// 
-			// iptext
-			// 
-			this.iptext.AutoSize = true;
-			this.iptext.BackColor = System.Drawing.Color.Transparent;
-			this.iptext.Font = new System.Drawing.Font("Microsoft Sans Serif", 9F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(238)));
-			this.iptext.ForeColor = System.Drawing.Color.White;
-			this.iptext.Location = new System.Drawing.Point(5, 5);
-			this.iptext.Name = "iptext";
-			this.iptext.Size = new System.Drawing.Size(24, 15);
-			this.iptext.TabIndex = 11;
-			this.iptext.Text = "IP: ";
-			// 
-			// nametext
-			// 
-			this.nametext.AutoSize = true;
-			this.nametext.BackColor = System.Drawing.Color.Transparent;
-			this.nametext.Font = new System.Drawing.Font("Microsoft Sans Serif", 9F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(238)));
-			this.nametext.ForeColor = System.Drawing.Color.White;
-			this.nametext.Location = new System.Drawing.Point(5, 24);
-			this.nametext.Name = "nametext";
-			this.nametext.Size = new System.Drawing.Size(71, 15);
-			this.nametext.TabIndex = 11;
-			this.nametext.Text = "Username: ";
-			// 
-			// presetlabel
-			// 
-			this.presetlabel.AutoSize = true;
-			this.presetlabel.BackColor = System.Drawing.Color.Transparent;
-			this.presetlabel.Font = new System.Drawing.Font("Microsoft Sans Serif", 9F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(238)));
-			this.presetlabel.ForeColor = System.Drawing.Color.White;
-			this.presetlabel.Location = new System.Drawing.Point(5, 44);
-			this.presetlabel.Name = "presetlabel";
-			this.presetlabel.Size = new System.Drawing.Size(62, 15);
-			this.presetlabel.TabIndex = 11;
-			this.presetlabel.Text = "Preset(s): ";
-			// 
-			// cb
-			// 
-			this.cb.BackColor = System.Drawing.Color.DimGray;
-			this.cb.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
-			this.cb.FlatStyle = System.Windows.Forms.FlatStyle.Popup;
-			this.cb.ForeColor = System.Drawing.Color.White;
-			this.cb.Items.AddRange(new object[] {
-			"Computernewb VM1",
-			"Computernewb VM2",
-			"Computernewb VM3",
-			"Computernewb VM4",
-			"Computernewb VM5",
-			"Computernewb VM6",
-			"Computernewb VM7",
-			"Computernewb VM8",
-			"Computernewb VM0b0t"});
-			this.cb.Location = new System.Drawing.Point(73, 44);
-			this.cb.Name = "cb";
-			this.cb.Size = new System.Drawing.Size(141, 21);
-			this.cb.TabIndex = 7;
-			this.cb.SelectedIndexChanged += new System.EventHandler(this.Cb_SelectedIndexChanged);
-			//
-			// checksecure
-			//
-			this.checksecure.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(64)))), ((int)(((byte)(64)))), ((int)(((byte)(64)))));
-			this.checksecure.FlatStyle = System.Windows.Forms.FlatStyle.Popup;
-			this.checksecure.ForeColor = System.Drawing.Color.White;
-			this.checksecure.Location = new System.Drawing.Point(8, 132);
-			this.checksecure.Name = "checksecure";
-			this.checksecure.Size = new System.Drawing.Size(180, 23);
-			this.checksecure.TabIndex = 3;
-			this.checksecure.Text = "Connect using TLS 1.2";
-			this.checksecure.Checked = false;
-			this.checksecure.UseVisualStyleBackColor = false;
-			this.checksecure.Click += new System.EventHandler(this.SecureCheck_Click);
-			//
-			// checkcompression
-			//
-			this.checkcompression.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(64)))), ((int)(((byte)(64)))), ((int)(((byte)(64)))));
-			this.checkcompression.FlatStyle = System.Windows.Forms.FlatStyle.Popup;
-			this.checkcompression.ForeColor = System.Drawing.Color.White;
-			this.checkcompression.Location = new System.Drawing.Point(8, 152);
-			this.checkcompression.Name = "checkcompression";
-			this.checkcompression.Size = new System.Drawing.Size(180, 23);
-			this.checkcompression.TabIndex = 4;
-			this.checkcompression.Text = "Use Deflate Compression";
-			this.checkcompression.Checked = true;
-			this.checkcompression.UseVisualStyleBackColor = false;
-			// 
-			// ConnectDialog
-			// 
-			this.AcceptButton = this.okButton;
-			this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
-			this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-			this.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(64)))), ((int)(((byte)(64)))), ((int)(((byte)(64)))));
-			this.CancelButton = this.cancelButton;
-			this.ClientSize = new System.Drawing.Size(220, 210);
-			this.Controls.Add(this.textBox3);
-			this.Controls.Add(this.textBox);
-			this.Controls.Add(this.cb);
-			this.Controls.Add(this.presetlabel);
-			this.Controls.Add(this.nametext);
-			this.Controls.Add(this.iptext);
-			this.Controls.Add(this.namewarning);
-			this.Controls.Add(this.cancelButton);
-			this.Controls.Add(this.okButton);
-			this.Controls.Add(this.textBox2);
-			this.Controls.Add(this.checksecure);
-			this.Controls.Add(this.checkcompression);
-			this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedDialog;
-			this.Icon = Icon.ExtractAssociatedIcon(System.Reflection.Assembly.GetExecutingAssembly().Location);
-			this.Name = "ConnectDialog";
-			this.Text = "Connect to...";
-			this.ResumeLayout(false);
-			this.PerformLayout();
+            // 
+            // iptext
+            // 
+            this.iptext.AutoSize = true;
+            this.iptext.BackColor = System.Drawing.Color.Transparent;
+            this.iptext.Font = new System.Drawing.Font("Microsoft Sans Serif", 9F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(238)));
+            this.iptext.ForeColor = System.Drawing.Color.White;
+            this.iptext.Location = new System.Drawing.Point(5, 5);
+            this.iptext.Name = "iptext";
+            this.iptext.Size = new System.Drawing.Size(24, 15);
+            this.iptext.TabIndex = 11;
+            this.iptext.Text = "IP: ";
+            // 
+            // nametext
+            // 
+            this.nametext.AutoSize = true;
+            this.nametext.BackColor = System.Drawing.Color.Transparent;
+            this.nametext.Font = new System.Drawing.Font("Microsoft Sans Serif", 9F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(238)));
+            this.nametext.ForeColor = System.Drawing.Color.White;
+            this.nametext.Location = new System.Drawing.Point(5, 24);
+            this.nametext.Name = "nametext";
+            this.nametext.Size = new System.Drawing.Size(71, 15);
+            this.nametext.TabIndex = 11;
+            this.nametext.Text = "Username: ";
+            // 
+            // presetlabel
+            // 
+            this.presetlabel.AutoSize = true;
+            this.presetlabel.BackColor = System.Drawing.Color.Transparent;
+            this.presetlabel.Font = new System.Drawing.Font("Microsoft Sans Serif", 9F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(238)));
+            this.presetlabel.ForeColor = System.Drawing.Color.White;
+            this.presetlabel.Location = new System.Drawing.Point(5, 44);
+            this.presetlabel.Name = "presetlabel";
+            this.presetlabel.Size = new System.Drawing.Size(62, 15);
+            this.presetlabel.TabIndex = 11;
+            this.presetlabel.Text = "Preset(s): ";
+            // 
+            // cb
+            // 
+            this.cb.BackColor = System.Drawing.Color.DimGray;
+            this.cb.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+            this.cb.FlatStyle = System.Windows.Forms.FlatStyle.Popup;
+            this.cb.ForeColor = System.Drawing.Color.White;
+            this.cb.Items.AddRange(new object[] {
+            "Computernewb VM1",
+            "Computernewb VM2",
+            "Computernewb VM3",
+            "Computernewb VM4",
+            "Computernewb VM5",
+            "Computernewb VM6",
+            "Computernewb VM7",
+            "Computernewb VM8",
+            "Computernewb VM0b0t"});
+            this.cb.Location = new System.Drawing.Point(73, 44);
+            this.cb.Name = "cb";
+            this.cb.Size = new System.Drawing.Size(141, 21);
+            this.cb.TabIndex = 7;
+            this.cb.SelectedIndexChanged += new System.EventHandler(this.Cb_SelectedIndexChanged);
+            // 
+            // checksecure
+            // 
+            this.checksecure.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(64)))), ((int)(((byte)(64)))), ((int)(((byte)(64)))));
+            this.checksecure.FlatStyle = System.Windows.Forms.FlatStyle.Popup;
+            this.checksecure.ForeColor = System.Drawing.Color.White;
+            this.checksecure.Location = new System.Drawing.Point(8, 132);
+            this.checksecure.Name = "checksecure";
+            this.checksecure.Size = new System.Drawing.Size(180, 23);
+            this.checksecure.TabIndex = 3;
+            this.checksecure.Text = "Connect using TLS 1.2";
+            this.checksecure.UseVisualStyleBackColor = false;
+            this.checksecure.Click += new System.EventHandler(this.SecureCheck_Click);
+            // 
+            // ConnectDialog
+            // 
+            this.AcceptButton = this.okButton;
+            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(64)))), ((int)(((byte)(64)))), ((int)(((byte)(64)))));
+            this.CancelButton = this.cancelButton;
+            this.ClientSize = new System.Drawing.Size(220, 185);
+            this.Controls.Add(this.textBox3);
+            this.Controls.Add(this.textBox);
+            this.Controls.Add(this.cb);
+            this.Controls.Add(this.presetlabel);
+            this.Controls.Add(this.nametext);
+            this.Controls.Add(this.iptext);
+            this.Controls.Add(this.namewarning);
+            this.Controls.Add(this.cancelButton);
+            this.Controls.Add(this.okButton);
+            this.Controls.Add(this.textBox2);
+            this.Controls.Add(this.checksecure);
+            this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedDialog;
+            this.Icon = Icon.ExtractAssociatedIcon(System.Reflection.Assembly.GetExecutingAssembly().Location);
+            this.Name = "ConnectDialog";
+            this.Text = "Connect to...";
+            this.ResumeLayout(false);
+            this.PerformLayout();
 
         }
 
@@ -248,7 +232,6 @@ namespace CollabClient
         private System.Windows.Forms.Label nametext;
         private System.Windows.Forms.Label presetlabel;
 		private System.Windows.Forms.CheckBox checksecure;
-		private System.Windows.Forms.CheckBox checkcompression;
         private System.Windows.Forms.ComboBox cb;
     }
 }

--- a/ConnectDialog.cs
+++ b/ConnectDialog.cs
@@ -19,55 +19,46 @@ namespace CollabClient
                     textBox.Text = "computernewb.com:443/collab-vm/vm1";
 					textBox2.Text = "vm1";
 					checksecure.Checked = true;
-					checkcompression.Checked = true;
 					break;
 				case 2:
                     textBox.Text = "computernewb.com:443/collab-vm/vm2";
 					textBox2.Text = "vm2";
 					checksecure.Checked = true;
-					checkcompression.Checked = true;
 					break;
 				case 3:
 					textBox.Text = "computernewb.com:443/collab-vm/vm3";
 					textBox2.Text = "vm3";
 					checksecure.Checked = true;
-					checkcompression.Checked = true;
 					break;
 				case 4:
 					textBox.Text = "computernewb.com:443/collab-vm/vm4";
 					textBox2.Text = "vm4";
 					checksecure.Checked = true;
-					checkcompression.Checked = true;
 					break;
 				case 5:
 					textBox.Text = "computernewb.com:443/collab-vm/vm5";
 					textBox2.Text = "vm5";
 					checksecure.Checked = true;
-					checkcompression.Checked = true;
 					break;
 				case 6:
 					textBox.Text = "computernewb.com:443/collab-vm/vm6";
 					textBox2.Text = "vm6";
 					checksecure.Checked = true;
-					checkcompression.Checked = true;
 					break;
 				case 7:
 					textBox.Text = "computernewb.com:443/collab-vm/vm7";
 					textBox2.Text = "vm7";
 					checksecure.Checked = true;
-					checkcompression.Checked = true;
 					break;				
 				case 8:
 					textBox.Text = "computernewb.com:443/collab-vm/vm8";
 					textBox2.Text = "vm8";
 					checksecure.Checked = true;
-					checkcompression.Checked = true;
 					break;
 				case 9:
 					textBox.Text = "computernewb.com:443/collab-vm/vm0";
 					textBox2.Text = "vm0b0t";
 					checksecure.Checked = true;
-					checkcompression.Checked = true;
 					break;
 			}
 		}
@@ -78,7 +69,6 @@ namespace CollabClient
 			Globals.vmname = textBox2.Text;
 			Globals.vmusername = textBox3.Text;
 			Globals.isSecure = checksecure.Checked;
-			Globals.isCompressed = checkcompression.Checked;
 			Hide();
 			new Form1().Show();
 		}

--- a/README.md
+++ b/README.md
@@ -9,5 +9,3 @@ yes the key handler is awful
 i know many of these problems
 
 originally by someone who doesn't want his name shared but has gladly agreed for me to repost this
-
-oh yeah you'll probably need a copy of [websocket-sharp](https://github.com/sta/websocket-sharp)

--- a/WebSocket.cs
+++ b/WebSocket.cs
@@ -1,0 +1,166 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Net.WebSockets;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace CollabClient
+{
+    public class WebSocket
+    {
+        // Fields
+        private ClientWebSocket socket;
+        private Uri uri;
+        private string[] protocols;
+        private bool closeHandled = false;
+
+        // Properties
+        
+        public string Uri => uri.ToString();
+        public string[] Protocols => protocols.ToArray();
+        public Dictionary<string,string> Headers { get; set; }
+
+        // Events
+        public event EventHandler<WebSocketCloseEventArgs> OnClose;
+        public event EventHandler OnOpen;
+        public event EventHandler<string> OnTextMessage;
+        public event EventHandler<byte[]> OnBinaryMessage;
+
+        // Methods
+        public WebSocket(string url, params string[] protocols)
+        {
+            this.uri = new Uri(url);
+            this.protocols = protocols;
+            this.Headers = new Dictionary<string, string>();
+            // Register dummy handlers on events to prevent NullReferenceException
+            OnClose += (s, e) => { };
+            OnOpen += (s, e) => { };
+            OnTextMessage += (s, e) => { };
+            OnBinaryMessage += (s, e) => { };
+
+        }
+
+        public void Close(WebSocketCloseStatus status = WebSocketCloseStatus.NormalClosure, string reason = "")
+        {
+            if (this.socket.State != WebSocketState.Open) return;
+            closeHandled = true;
+            this.socket.CloseAsync(status, reason, CancellationToken.None).GetAwaiter().GetResult();
+            this.socket.Dispose();
+            this.socket = null;
+            OnClose.Invoke(this, new WebSocketCloseEventArgs
+            {
+                Code = status,
+                Reason = WebSocketCloseReason.CloseByClient,
+                Message = reason,
+            });
+            closeHandled = false;
+        }
+
+        public async Task Connect()
+        {
+            if (this.socket != null && this.socket.State == WebSocketState.Open) Close();
+            this.socket = new ClientWebSocket();
+            foreach (string protocol in this.protocols) this.socket.Options.AddSubProtocol(protocol);
+            foreach (KeyValuePair<string, string> header in Headers) this.socket.Options.SetRequestHeader(header.Key, header.Value);
+            await this.socket.ConnectAsync(this.uri, CancellationToken.None);
+            messageLoop();
+            this.OnOpen.Invoke(this, new EventArgs());
+
+        }
+
+        public bool Send(string msg)
+        {
+            return Send(Encoding.UTF8.GetBytes(msg), WebSocketMessageType.Text);
+        }
+
+        public bool Send(byte[] msg, WebSocketMessageType type = WebSocketMessageType.Binary)
+        {
+            if (this.socket == null || this.socket.State != WebSocketState.Open) return false;
+            this.socket.SendAsync(new ArraySegment<byte>(msg), type, true, CancellationToken.None).GetAwaiter().GetResult();
+            return true;
+        }
+
+        private async void messageLoop()
+        {
+            ArraySegment<byte> recieveBuffer = new ArraySegment<byte>(new byte[8192]);
+            do
+            {
+                using (var ms = new MemoryStream())
+                {
+                    WebSocketReceiveResult res;
+                    do
+                    {
+                        try
+                        {
+                            res = await socket.ReceiveAsync(recieveBuffer, CancellationToken.None);
+                        }
+                        catch (WebSocketException ex)
+                        {
+                            if (this.socket == null || closeHandled) return;
+                            this.socket.Dispose();
+                            this.socket = null;
+                            this.OnClose.Invoke(this, new WebSocketCloseEventArgs
+                            {
+                                Code = null,
+                                Reason = WebSocketCloseReason.Error,
+                                Message = ex.Message,
+                            });
+                            return;
+                        }
+                        if (res.MessageType == WebSocketMessageType.Close)
+                        {
+                            if (this.socket == null || closeHandled) return;
+                            this.socket.Dispose();
+                            this.socket = null;
+                            this.OnClose.Invoke(this, new WebSocketCloseEventArgs
+                            {
+                                Code = res.CloseStatus,
+                                Reason = WebSocketCloseReason.CloseByServer,
+                                Message = res.CloseStatusDescription
+                            });
+                            return;
+                        }
+                        await ms.WriteAsync(recieveBuffer.Array, 0, res.Count);
+                    } while (!res.EndOfMessage);
+                    byte[] msgbytes = ms.ToArray();
+                    if (res.MessageType == WebSocketMessageType.Binary) this.OnBinaryMessage.Invoke(this, msgbytes);
+                    else if (res.MessageType == WebSocketMessageType.Text) this.OnTextMessage.Invoke(this, Encoding.UTF8.GetString(msgbytes));
+                }
+            } while (socket.State == WebSocketState.Open);
+            if (this.socket == null || closeHandled) return;
+            // this shouldn't happen I don't think but we'll handle it anyway
+            this.socket.Dispose();
+            this.socket = null;
+            this.OnClose.Invoke(this, new WebSocketCloseEventArgs
+            {
+                Code = null,
+                Reason = WebSocketCloseReason.CloseByServer,
+                Message = ""
+            });
+            return;
+        }
+    }
+
+    public class WebSocketCloseEventArgs
+    {
+        /// <summary>
+        /// Closure code provided by the server, or null if the connection closed uncleanly
+        /// </summary>
+        public WebSocketCloseStatus? Code { get; set; }
+        /// <summary>
+        /// The reason for the closure
+        /// </summary>
+        public WebSocketCloseReason Reason { get; set; }
+        public string Message { get; set; }
+    }
+
+    public enum WebSocketCloseReason
+    {
+        CloseByClient,
+        CloseByServer,
+        Error
+    }
+}

--- a/collabvm-client-dotnet.csproj
+++ b/collabvm-client-dotnet.csproj
@@ -52,9 +52,6 @@
     <Reference Include="System.Drawing" />
     <Reference Include="System.Windows.Forms" />
     <Reference Include="System.Xml" />
-    <Reference Include="websocket-sharp, Version=1.0.2.59611, Culture=neutral, PublicKeyToken=5660b08a1845a91e, processorArchitecture=MSIL">
-      <HintPath>packages\WebSocketSharp.1.0.3-rc11\lib\websocket-sharp.dll</HintPath>
-    </Reference>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="APIPayloads.cs" />
@@ -127,6 +124,7 @@
       <DependentUpon>Settings.settings</DependentUpon>
       <DesignTimeSharedInput>True</DesignTimeSharedInput>
     </Compile>
+    <Compile Include="WebSocket.cs" />
     <Compile Include="X11KeyEnum.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/packages.config
+++ b/packages.config
@@ -1,5 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Newtonsoft.Json" version="13.0.3" targetFramework="net471" />
-  <package id="WebSocketSharp" version="1.0.3-rc11" targetFramework="net461" />
 </packages>


### PR DESCRIPTION
This removes the tech debt that is WebSocketSharp
- Fully port everything over to System.Net.WebSockets.ClientWebSocket
- To do this, I've created a new wrapper WebSocket class in WebSocket.cs to wrap a message loop and such. It's mostly compatible with WebSocketSharp.WebSocket aside from some changes I made
- In my testing the VM seems much faster than with wssharp
- Removes the WebSocketSharp reference

However, there are some trade-offs you'll want to consider before merging
- Windows 7 is no longer supported as ClientWebSocket does not support it (However, I seriously hope nobody is still using Windows 7 in 2024)
- DEFLATE compression is also not supported. However, this is also considered a security vulnerability when using SSL so I'm not sure how much of a loss that actually is